### PR TITLE
docs(readme): remove snyk badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![CI](https://github.com/fastify/fastify-hotwire/workflows/CI/badge.svg)
 [![NPM version](https://img.shields.io/npm/v/@fastify/hotwire.svg?style=flat)](https://www.npmjs.com/package/@fastify/hotwire)
-[![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify-hotwire/badge.svg)](https://snyk.io/test/github/fastify/fastify-hotwire)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 Do you enjoy writing applications with the [hotwire](http://hotwire.dev) pattern?


### PR DESCRIPTION
 Snyk badge can be removed as the dependency-review job, which is now part of the [reusable workflow](https://github.com/fastify/workflows/blob/main/.github/workflows/plugins-ci.yml), does the same thing as Snyk. See https://github.com/fastify/fastify/issues/3883

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
