### PR TITLE
test: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,8 +1,0 @@
-ts: false
-jsx: false
-flow: false
-coverage: true
-check-coverage: true
-
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap"
+    "test:unit": "c8 -100 node --test"
   },
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
     "@fastify/websocket": "^11.0.1",
     "@hotwired/turbo": "^8.0.10",
     "@types/node": "^22.5.5",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "mqemitter": "^6.0.2",
     "pino-pretty": "^13.0.0",
@@ -46,7 +47,6 @@
     "standard": "^17.0.0",
     "superheroes": "^4.0.0",
     "svelte": "^3.44.0",
-    "tap": "^16.0.0",
     "tsd": "^0.31.2"
   },
   "publishConfig": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { join } = require('node:path')
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const Hotwire = require('..')
 
@@ -21,9 +21,9 @@ test('Should render the entire page', async t => {
     path: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.match(response.headers, { 'content-type': 'text/html; charset=utf-8' })
-  t.ok(response.payload.includes('foobar'))
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+  t.assert.ok(response.payload.includes('foobar'))
 })
 
 function runTurboStream (action) {
@@ -53,9 +53,9 @@ function runTurboStream (action) {
       path: '/'
     })
 
-    t.equal(response.statusCode, 200)
-    t.match(response.headers, { 'content-type': 'text/vnd.turbo-stream.html; charset=utf-8' })
-    t.equal(response.payload.replace(/\n/g, '').trim(), `<turbo-stream action="${action}" target="messages">    <template>      <turbo-frame id="message_frame_unique"><p><strong>foobar:</strong> hello world</p>  <form action="/message/unique/delete" method="POST"><button type="submit">Remove</button></form></turbo-frame>    </template>  </turbo-stream>`)
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.headers['content-type'], 'text/vnd.turbo-stream.html; charset=utf-8')
+    t.assert.strictEqual(response.payload.replace(/\n/g, '').trim(), `<turbo-stream action="${action}" target="messages">    <template>      <turbo-frame id="message_frame_unique"><p><strong>foobar:</strong> hello world</p>  <form action="/message/unique/delete" method="POST"><button type="submit">Remove</button></form></turbo-frame>    </template>  </turbo-stream>`)
   })
 }
 
@@ -87,9 +87,9 @@ function runTurboGenerate (action) {
       path: '/'
     })
 
-    t.equal(response.statusCode, 200)
-    t.match(response.headers, { 'content-type': 'text/plain' })
-    t.equal(response.payload, `<turbo-stream action="${action}" target="messages">    <template>      <turbo-frame id="message_frame_unique"><p><strong>foobar:</strong> hello world</p>  <form action="/message/unique/delete" method="POST"><button type="submit">Remove</button></form></turbo-frame>    </template>  </turbo-stream>`)
+    t.assert.strictEqual(response.statusCode, 200)
+    t.assert.strictEqual(response.headers['content-type'], 'text/plain')
+    t.assert.strictEqual(response.payload, `<turbo-stream action="${action}" target="messages">    <template>      <turbo-frame id="message_frame_unique"><p><strong>foobar:</strong> hello world</p>  <form action="/message/unique/delete" method="POST"><button type="submit">Remove</button></form></turbo-frame>    </template>  </turbo-stream>`)
   })
 }
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
