### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @fastify/hotwire
 
-[![CI](https://github.com/fastify/fastify-hotwire/actions/workflows/ci.yml/badge.svg)](https://github.com/fastify/fastify-hotwire/actions/workflows/ci.yml)
+[![CI](https://github.com/fastify/fastify-hotwire/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/fastify-hotwire/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/hotwire.svg?style=flat)](https://www.npmjs.com/package/@fastify/hotwire)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge