### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import fastify, { FastifyInstance } from 'fastify'
 import hotwire from '..'
-import { join } from 'path'
+import { join } from 'node:path'
 import { expectType } from 'tsd'
 
 const app: FastifyInstance = fastify()


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.