### PR TITLE
chore: upgrade piscina to v5.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,21 +36,29 @@ async function fastifyHotwire (fastify, opts) {
 
   async function render (file, data) {
     file = join(templates, file)
-    const html = await pool.runTask({ file, data, fragment: false })
+    const html = await pool.run({ file, data, fragment: false })
     this.type('text/html; charset=utf-8')
     this.send(html)
     return this
   }
 
   async function turboSend (that, action, file, target, data) {
-    const html = await pool.runTask({ file: join(templates, file), data, fragment: true })
+    const html = await pool.run({
+      file: join(templates, file),
+      data,
+      fragment: true
+    })
     that.type('text/vnd.turbo-stream.html; charset=utf-8')
     that.send(buildStream(action, target, html.trim()))
     return that
   }
 
   async function generate (_that, action, file, target, data) {
-    const html = await pool.runTask({ file: join(templates, file), data, fragment: true })
+    const html = await pool.run({
+      file: join(templates, file),
+      data,
+      fragment: true
+    })
     return buildStream(action, target, html).replace(/\n/g, '').trim()
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "fastify-plugin": "^5.0.0",
-    "piscina": "^4.0.0"
+    "piscina": "^5.0.0"
   },
   "devDependencies": {
     "@fastify/cookie": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     }
   ],
   "dependencies": {
-    "fastify-plugin": "^5.0.0",
+    "fastify-plugin": "^6.0.0",
     "piscina": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Proposal:

- Upgrade piscina v5.x ( https://github.com/piscinajs/piscina/releases/tag/v5.0.0 )

Changes:

- `piscina@5.0.0` removed `runTask()` in favor of `run()` (deprecated since v4). Since `index.js` still called `pool.runTask(...)` in `render`, `turboSend` and `generate`, every request threw `TypeError: pool.runTask is not a function`, which surfaced as 500s on all routes and made all 11 unit tests fail.


Note:
- This PR should resolved this PR: https://github.com/fastify/fastify-hotwire/pull/192 and https://github.com/fastify/fastify-hotwire/pull/214